### PR TITLE
fix: can not match property witch start with _

### DIFF
--- a/lib/parseEngineData.js
+++ b/lib/parseEngineData.js
@@ -1,4 +1,4 @@
-var iconv = require('iconv-lite')
+var utf16Decoder = new TextDecoder('utf-16');
 // engineData is an array form descriptor.coffee
 
 var MATCH_TYPE = [  hashStart,
@@ -178,7 +178,7 @@ function string(text){
             for (var i=0,l=txt.length;i<l;i++){
                 bf.push(txt.charCodeAt(i));
             }
-            return iconv.decode(new Buffer(bf), 'utf-16');//it`s utf-16 with bom
+            return utf16Decoder.decode(bf);//it`s utf-16 with bom
         }
     }
 }

--- a/lib/parseEngineData.js
+++ b/lib/parseEngineData.js
@@ -5,7 +5,7 @@ var MATCH_TYPE = [  hashStart,
                     hashEnd,
                     multiLineArrayStart,
                     multiLineArrayEnd,
-                    property, 
+                    property,
                     propertyWithData,
                     singleLineArray,
                     boolean,
@@ -103,7 +103,7 @@ function multiLineArrayEnd(text){
     }
 }
 function property(text){
-    var reg = /^\/([A-Z0-9]+)$/i;
+    var reg = /^\/([_A-Z0-9]+)$/i;
 
     return {
         match: Match(reg, text),

--- a/package.json
+++ b/package.json
@@ -1,30 +1,28 @@
 {
-  "name": "parse-engine-data",
-  "version": "0.1.2",
+  "name": "@noahlam/parse-engine-data",
+  "version": "0.1.3",
   "description": "parse engine data in psd file",
   "main": "./lib/parseEngineData.js",
-  "dependencies": {
-    "iconv-lite": "^0.4.4"
-  },
+  "dependencies": {},
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/imgqb/parseEngineData.git"
+    "url": "https://github.com/noahlam/parseEngineData.git"
   },
   "keywords": [
     "psd",
     "engineData"
   ],
   "author": {
-    "name": "imgqb",
-    "email": "iamgqb@gmail.com"
-    },
+    "name": "noahlam",
+    "email": "284516433@qq.com"
+  },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/imgqb/parseEngineData/issues"
+    "url": "https://github.com/noahlam/parseEngineData/issues"
   },
-  "homepage": "https://github.com/imgqb/parseEngineData"
+  "homepage": "https://github.com/noahlam/parseEngineData"
 }


### PR DESCRIPTION
Engine Data in this file ([demo.psd.zip](https://github.com/iamgqb/parseEngineData/files/7639073/demo.psd.zip)) may have some properties name starting with _, that will cause an error.

```
/Users/noah/code/parseEngine2/lib/parseEngineData.js:24
    return currentNode.shift();
                       ^

TypeError: currentNode.shift is not a function
    at paresr (/Users/noah/code/parseEngine2/lib/parseEngineData.js:24:24)
    at /Users/noah/code/parseEngine2/index.js:5:13
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:71:3)

```

correct the regExp within property handler function to solve it.

```diff
-   var reg = /^\/([A-Z0-9]+)$/i;
+   var reg = /^\/([_A-Z0-9]+)$/i;
```


here is test Endine Data: [test engine data.zip](https://github.com/iamgqb/parseEngineData/files/7639102/test.engine.data.zip)

