### PR TITLE
error when parse a big EngineData

### DIFF
--- a/lib/parseEngineData.js
+++ b/lib/parseEngineData.js
@@ -26,7 +26,15 @@ var paresr = function(engineData){
 
 
 function codeToString(engineData){
-    return String.fromCharCode.apply(null, engineData);
+//     return String.fromCharCode.apply(null, engineData);
+    var res = '';
+    var chunk = 8 * 1024;
+    var i;
+    for (i = 0; i < engineData.length / chunk; i++) {
+    res += String.fromCharCode.apply(null, engineData.slice(i * chunk, (i + 1) * chunk));
+    }
+    res += String.fromCharCode.apply(null, engineData.slice(i * chunk));
+    return res;
 }
 
 function textSegment(text){
@@ -67,7 +75,7 @@ function hashStart(text){
     return {
         match: Match(reg, text),
         parse: function(){
-            stackPush({});
+            stackPush([]);
         }
     }
 }


### PR DESCRIPTION
Maximum call stack size exceeded when parsing big engine data